### PR TITLE
Warn when a remote is specified, but is not found.

### DIFF
--- a/lib/Dist/Zilla/Plugin/GithubMeta.pm
+++ b/lib/Dist/Zilla/Plugin/GithubMeta.pm
@@ -54,9 +54,24 @@ sub _acquire_repo_info {
   return unless can_run('git');
 
   my $git_url;
-  for my $remote (@{ $self->remote }) {
-    next unless $git_url = $self->_url_for_remote($remote);
-    last if $git_url =~ m!\bgithub\.com[:/]!; # Not a Github repository
+  remotelist: for my $remote (@{ $self->remote }) {
+    # Missing remotes expand to the same value as they were input
+    # ( git version 1.7.7 -- kentnl -- 2011-10-08 )
+    unless ( $git_url = $self->_url_for_remote($remote) and $remote ne $git_url ) {
+      $self->log(
+        ['A remote named \'%s\' was specified, but does not appear to exist.', $remote ]
+      );
+      undef $git_url;
+      next remotelist;
+    }
+    last if $git_url =~ m!\bgithub\.com[:/]!; # Short Circuit on Github repository
+
+    # Not a Github Repository?
+    $self->log( [
+        'Specified remote \'%s\' expanded to \'%s\', which is not a github repository URL',
+        $remote, $git_url,
+    ] );
+
     undef $git_url;
   }
 
@@ -69,6 +84,9 @@ sub _acquire_repo_info {
     $
   }ix;
 
+  $self->log(['No user could be discerned from URL: \'%s\'', $git_url ]) unless defined $user ;
+  $self->log(['No repository could be discerned from URL: \'%s\'', $git_url ]) unless defined $repo;
+
   return unless defined $user and defined $repo;
 
   $self->user($user) unless $self->_has_user;
@@ -80,7 +98,10 @@ sub metadata {
 
   $self->_acquire_repo_info;
 
-  return unless $self->_has_user and $self->_has_repo;
+  unless ( $self->_has_user and $self->_has_repo ){
+    $self->log(['skipping meta.resources.repository creation'] );
+    return;
+  }
 
   my $gh_url  = sprintf 'https://github.com/%s/%s', $self->user, $self->repo;
   my $bug_url = "$gh_url/issues";


### PR DESCRIPTION
This scenario can cause some rather nasty problems, and have some hidden
side effects, especially if the user has other plugins that are relying
on GithubMeta to populate the metadata-stash , but it silently does not.

Instead of just silently trucking along and failing to populate
metadata, it now does:

```
[@Filter/GithubMeta] A remote named 'github' was specified, but does not appear to exist.
[@Filter/GithubMeta] skipping meta.resources.repository creation
```

Which will be a bit more helpful if something goes wrong because of
this. ( And its incredibly likely that remote names for new clones wont
match the remote names used somewhere else )

Have to add an explict `undef` before `next` too.

Otherwise, for the last item that fails, "next" jumps past the undef,
  causing the code to try parsing a user and repo out of the whatever
  the result of the last call to `_url_for_remote` returned.

And this could be either nothing, complete garbage, or the remote name
itself, ( the remote name itself appears in the output of `git remote
    show -n foobar` when that remote doesn't even exist:

```
> git remote show -n foobar
* remote foobar
  Fetch URL: foobar
  Push  URL: foobar
  HEAD branch: (not queried)
  Local ref configured for 'git push' (status not queried):
    (matching) pushes to (matching)
```

This is unessecary effort, and makes further error reporting/diagnostics
needlessly noisy.
