### PR TITLE
use git remote command to fetch remote urls

### DIFF
--- a/lib/Dist/Zilla/Plugin/GithubMeta.pm
+++ b/lib/Dist/Zilla/Plugin/GithubMeta.pm
@@ -125,10 +125,14 @@ sub metadata {
 
 sub _url_for_remote {
   my ($self, $remote) = @_;
-  my $url = `git config --get remote.$remote.url`;
-  chomp $url;
-
-  return $url;
+  my @remote_info = `git remote show -n $remote`;
+  for my $line (@remote_info) {
+    chomp $line;
+    if ($line =~ /^\s*Fetch URL:\s*(.*)/) {
+      return $1;
+    }
+  }
+  return;
 }
 
 sub _under_git {


### PR DESCRIPTION
If the git url.<base>.insteadOf or url.<base>.pushInsteadOf options are
used, the URL listed in the config directly may not be the real URL used
for fetching.  The remote command will resolve the real URLs git will be
using, so use that instead.
