### PR TITLE
RT#99820 Simpler implementation of _url_for_remote using 'git config'

### DIFF
--- a/lib/Dist/Zilla/Plugin/GithubMeta.pm
+++ b/lib/Dist/Zilla/Plugin/GithubMeta.pm
@@ -136,16 +136,10 @@ sub metadata {
 
 sub _url_for_remote {
   my ($self, $remote) = @_;
-  local $ENV{LC_ALL}='C';
-  local $ENV{LANG}='C';
-  my @remote_info = `git remote show -n $remote`;
-  for my $line (@remote_info) {
-    chomp $line;
-    if ($line =~ /^\s*(?:Fetch)?\s*URL:\s*(.*)/) {
-      return $1;
-    }
-  }
-  return;
+  my $url = `git config --local --get "remote.$remote.url"`;
+  return if $? >> 8;
+  chomp $url;
+  $url
 }
 
 sub _under_git {


### PR DESCRIPTION
Simpler implementation of _url_for_remote using `git config` instead of parsing the output of `git remote show -n` that is designed for humans.

This is [RT#99820](https://rt.cpan.org/Ticket/Display.html?id=99820)
