### PR TITLE
avoid meta validation issues by testing the data directly, not the json rendering

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use Test::More 0.88;
 use IPC::Cmd qw[can_run];
+use Test::Deep;
 
 unless ( can_run('git') ) {
   ok('No git, no dice');
@@ -109,7 +110,6 @@ sub test_plugin {
     {
       add_files => {
         'source/dist.ini'    => simple_ini(
-          'MetaJSON',
           [ GithubMeta => $test->{plugin} ],
         ),
         'source/.git/config' => git_config_for($test->{git}),
@@ -122,8 +122,8 @@ sub test_plugin {
 
   $tzil->build;
 
-  is_json(
-    $tzil->slurp_file('build/META.json'),
+  cmp_deeply(
+    $tzil->distmeta,
     all(
       $test->{meta} || ignore(),
       superhashof({


### PR DESCRIPTION

When CPAN::Meta and Dist::Zilla versions are out of sync, we can get errors like this:

```
[MetaJSON] Invalid META structure.  Errors found:
[MetaJSON] Expected a list structure (license) [Validation: 2] at /Volumes/amaretto/Users/ether/.perlbrew/libs/20.0@std/lib/perl5/darwin-2level/Moose/Meta/Method/Delegation.pm line 110.
t/basic.t .. Dubious, test returned 25 (wstat 6400, 0x1900)
```

...which aren't your problem. Avoid all this by just testing `$tzil->distmeta` directly.