### PR TITLE
Do not assume that the current directory is already the distribution root

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -18,3 +18,4 @@ Moose                           = 1.07
 MooseX::Types::URI              = 0.03
 Try::Tiny                       = 0
 version                         = 0
+File::pushd                     = 0

--- a/lib/Dist/Zilla/Plugin/GithubMeta.pm
+++ b/lib/Dist/Zilla/Plugin/GithubMeta.pm
@@ -10,6 +10,7 @@ with 'Dist::Zilla::Role::MetaProvider';
 use MooseX::Types::URI qw[Uri];
 use Cwd;
 use Try::Tiny;
+use File::pushd 'pushd';
 
 use namespace::autoclean;
 
@@ -55,6 +56,7 @@ sub _acquire_repo_info {
   require IPC::Cmd;
   return unless IPC::Cmd::can_run('git');
 
+  my $wd = pushd $self->zilla->root;
   {
     my $gitver = `git version`;
     my ($ver) = $gitver =~ m!git version ([0-9.]+(\.msysgit)?[0-9.]+)!;


### PR DESCRIPTION
This assumption is no longer true with Dist::Zilla 7.000.