### PR TITLE
real fix for Dist::Zilla 7.000

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -19,3 +19,8 @@ MooseX::Types::URI              = 0.03
 Try::Tiny                       = 0
 version                         = 0
 File::pushd                     = 0
+
+[Prereqs / TestRequires]
+Test::More = 0.88
+Test::Deep = 0
+Test::DZil = 0

--- a/dist.ini
+++ b/dist.ini
@@ -24,3 +24,4 @@ File::pushd                     = 0
 Test::More = 0.88
 Test::Deep = 0
 Test::DZil = 0
+Path::Tiny = 0

--- a/lib/Dist/Zilla/Plugin/GithubMeta.pm
+++ b/lib/Dist/Zilla/Plugin/GithubMeta.pm
@@ -49,6 +49,8 @@ sub mvp_multivalue_args { qw(remote) }
 sub _acquire_repo_info {
   my ($self) = @_;
 
+  my $wd = pushd $self->zilla->root;
+
   return if $self->_has_user and $self->_has_repo;
 
   return unless _under_git();
@@ -56,7 +58,6 @@ sub _acquire_repo_info {
   require IPC::Cmd;
   return unless IPC::Cmd::can_run('git');
 
-  my $wd = pushd $self->zilla->root;
   {
     my $gitver = `git version`;
     my ($ver) = $gitver =~ m!git version ([0-9.]+(\.msysgit)?[0-9.]+)!;

--- a/t/basic.t
+++ b/t/basic.t
@@ -116,7 +116,6 @@ sub test_plugin {
     {
       add_files => {
         'source/dist.ini'    => simple_ini(
-          'MetaJSON',
           [ GithubMeta => $test->{plugin} ],
         ),
         'source/.git/config' => git_config_for($test->{git}),

--- a/t/basic.t
+++ b/t/basic.t
@@ -4,36 +4,11 @@ use Test::More 0.88;
 use IPC::Cmd qw[can_run];
 use Try::Tiny;
 use Test::Deep;
-
-unless ( can_run('git') ) {
-  ok('No git, no dice');
-  done_testing;
-  exit 0;
-}
-
-{
-  my ($gitver) = `git version`;
-  my ($ver) = $gitver =~ m!git version ([0-9.]+(\.msysgit)?[0-9.]+)!;
-  $ver =~ s![^\d._]!!g;
-  $ver =~ s!\.$!!;
-  $ver =~ s!\.+!.!g;
-  chomp $gitver;
-  require version;
-  my $ver_obj = try { version->parse( $ver ) }
-    catch { die "'$gitver' not parsable as '$ver': $_" };
-  if ( $ver_obj < version->parse('1.5.0') ) {
-    diag("$gitver is too low, 1.5.0 or above is required");
-    ok("$gitver is too low, 1.5.0 or above is required");
-    done_testing;
-    exit 0;
-  }
-  diag("Using $gitver\n");
-}
+use Test::DZil;
 
 use lib 't/lib';
+use GitSetup;
 
-use Test::Deep qw(all ignore superhashof);
-use Test::DZil;
 
 test_plugin("simplest case, ssh url" => {
   plugin => { },
@@ -109,11 +84,15 @@ sub git_config_for {
 
 sub test_plugin {
   my ($desc, $test) = @_;
+
+  my $tempdir = no_git_tempdir();
+
   my $gitconfig = git_config_for($test);
 
   my $tzil = Builder->from_config(
     { dist_root => 'corpus/GHM-Sample' },
     {
+      tempdir_root => $tempdir->stringify,
       add_files => {
         'source/dist.ini'    => simple_ini(
           [ GithubMeta => $test->{plugin} ],

--- a/t/basic.t
+++ b/t/basic.t
@@ -127,6 +127,7 @@ sub test_plugin {
     },
   );
 
+  $tzil->chrome->logger->set_debug(1);
   $tzil->build;
 
   cmp_deeply(
@@ -147,4 +148,7 @@ sub test_plugin {
     ),
     $desc,
   );
+
+  diag 'got log messages: ', explain $tzil->log_messages
+    if not Test::Builder->new->is_passing;
 }

--- a/t/lib/GitSetup.pm
+++ b/t/lib/GitSetup.pm
@@ -1,0 +1,72 @@
+use strict;
+use warnings;
+package GitSetup;
+
+use Test::More;
+use Path::Tiny;
+
+use Exporter 5.57 'import';
+our @EXPORT = qw(no_git_tempdir);
+
+$ENV{HOME} = Path::Tiny->tempdir->stringify;
+
+unless ( can_run('git') ) {
+  ok('No git, no dice');
+  done_testing;
+  exit 0;
+}
+
+{
+  my ($gitver) = `git version`;
+  my ($ver) = $gitver =~ m!git version ([0-9.]+(\.msysgit)?[0-9.]+)!;
+  $ver =~ s![^\d._]!!g;
+  $ver =~ s!\.$!!;
+  $ver =~ s!\.+!.!g;
+  chomp $gitver;
+  require version;
+  my $ver_obj = try { version->parse( $ver ) }
+    catch { die "'$gitver' not parsable as '$ver': $_" };
+  if ( $ver_obj < version->parse('1.5.0') ) {
+    diag("$gitver is too low, 1.5.0 or above is required");
+    ok("$gitver is too low, 1.5.0 or above is required");
+    done_testing;
+    exit 0;
+  }
+  diag("Using $gitver\n");
+}
+
+# provides a temp directory that is guaranteed to not be inside a git repository
+# copied from Dist-Zilla-Plugin-Git-Contributors/t/lib/GitSetup.pm
+sub no_git_tempdir
+{
+    my $tempdir = Path::Tiny->tempdir(CLEANUP => 1);
+    mkdir $tempdir if not -d $tempdir;    # FIXME: File::Temp::newdir doesn't make the directory?!
+
+    {
+        my $in_git;
+        my $dir = $tempdir;
+        my $count = 0;
+        while (not $dir->is_rootdir) {
+            # this should never happen.
+            do { diag "failed to detect that $dir is at the root?!"; last } if $dir eq $dir->parent;
+
+            my $checkdir = path($dir, '.git');
+            if (-d $checkdir) {
+                note "found $checkdir in $tempdir";
+                $in_git = 1;
+                last;
+            }
+            $dir = $dir->parent;
+        }
+        continue {
+            die "too many iterations when traversing $tempdir!"
+                if $count++ > 100;
+        }
+
+        ok(!$in_git, 'tempdir is not in a real git repository');
+    }
+
+    return $tempdir;
+}
+
+1;


### PR DESCRIPTION
Change directories before running any git commands.
    
This test was passing when run from the development repository because
that repo's config was being picked up, but then tests would fail when
running tests during a normal cpan installation, doh!